### PR TITLE
Match users based on who has the most mutual preferences

### DIFF
--- a/step/src/main/java/com/google/sps/DatabaseHandler.java
+++ b/step/src/main/java/com/google/sps/DatabaseHandler.java
@@ -49,6 +49,11 @@ public final class DatabaseHandler {
   private static final String FIRST_NAME =  "firstName";
   private static final String LAST_NAME = "lastName";
   private static final String MATCH_PENDING = "matchPending"; 
+  private static final String QUESTION_1 = "q1";
+  private static final String QUESTION_2 = "q2";
+  private static final String QUESTION_3 = "q3";
+  private static final String QUESTION_4 = "q4";
+  private static final String QUESTION_5 = "q5";
   private static final String EMAIL = "email";
   private static final String USER_ID = "userId";
   private static final String OTHER_USER_ID = "otherUserId";
@@ -83,6 +88,21 @@ public final class DatabaseHandler {
     entity.setProperty("id", id);
     entity.setProperty(MATCH_PENDING, false);
     datastore.put(entity);    
+  }
+
+  //Adding users' preferences info 
+  public static void addUserPref(String id, String q1, String q2, String q3, String q4, String q5) {
+    Query query =
+        new Query("User")
+            .setFilter(new Query.FilterPredicate("id", Query.FilterOperator.EQUAL, id));
+    PreparedQuery results = datastore.prepare(query);
+    Entity entity = results.asSingleEntity();
+    entity.setProperty("q1", q1);
+    entity.setProperty("q2", q2);
+    entity.setProperty("q3", q3);
+    entity.setProperty("q4", q4);
+    entity.setProperty("q5", q5);
+    datastore.put(entity);
   }
  
   // Adding a user's notificaton to the database
@@ -157,6 +177,30 @@ public final class DatabaseHandler {
       String firstName = (String) user.getProperty(FIRST_NAME);
       String lastName = (String) user.getProperty(LAST_NAME);
       return firstName + " " + lastName;
+    } catch (EntityNotFoundException e) {
+      System.err.println("Element not found: " + e.getMessage());
+      e.printStackTrace();
+      return null;
+    }
+  }
+
+  //Method for getting a user's preferences using their id
+  public static ArrayList<String> getUserPreferences(String id) {
+    try {
+        Entity user = datastore.get((new User(id)).getKey());
+        String q1 = (String) user.getProperty(QUESTION_1);
+        String q2 = (String) user.getProperty(QUESTION_2);
+        String q3 = (String) user.getProperty(QUESTION_3);
+        String q4 = (String) user.getProperty(QUESTION_4);
+        String q5 = (String) user.getProperty(QUESTION_5);
+
+        ArrayList<String> preferences = new ArrayList<>();
+        preferences.add(q1);
+        preferences.add(q2);
+        preferences.add(q3);
+        preferences.add(q4);
+        preferences.add(q5);
+        return preferences;
     } catch (EntityNotFoundException e) {
       System.err.println("Element not found: " + e.getMessage());
       e.printStackTrace();

--- a/step/src/main/java/com/google/sps/DatabaseHandler.java
+++ b/step/src/main/java/com/google/sps/DatabaseHandler.java
@@ -97,11 +97,11 @@ public final class DatabaseHandler {
             .setFilter(new Query.FilterPredicate("id", Query.FilterOperator.EQUAL, id));
     PreparedQuery results = datastore.prepare(query);
     Entity entity = results.asSingleEntity();
-    entity.setProperty("q1", q1);
-    entity.setProperty("q2", q2);
-    entity.setProperty("q3", q3);
-    entity.setProperty("q4", q4);
-    entity.setProperty("q5", q5);
+    entity.setProperty(QUESTION_1, q1);
+    entity.setProperty(QUESTION_2, q2);
+    entity.setProperty(QUESTION_3, q3);
+    entity.setProperty(QUESTION_4, q4);
+    entity.setProperty(QUESTION_5, q5);
     datastore.put(entity);
   }
  

--- a/step/src/main/java/com/google/sps/User.java
+++ b/step/src/main/java/com/google/sps/User.java
@@ -20,13 +20,13 @@ import java.util.ArrayList;
 import com.google.appengine.api.datastore.Key;
 import com.google.appengine.api.datastore.KeyFactory;
 
-
 public class User {
   
   private String userServiceUserId;
   private String email;
   private String name;
   private Collection<User> matches;
+  private ArrayList<String> preferences;
   private Key key;
 
   public User(String userServiceUserId) {
@@ -60,6 +60,14 @@ public class User {
       name = DatabaseHandler.getUserName(userServiceUserId);
     }
     return name;  
+  }
+
+  //Getter method for a user's preference answers
+  public ArrayList<String> getPreferences() {
+      if (preferences == null) {
+          preferences = DatabaseHandler.getUserPreferences(userServiceUserId);
+      }
+      return preferences;
   }
 
   // Getter method for a user's matches

--- a/step/src/main/java/com/google/sps/servlets/PrefServlet.java
+++ b/step/src/main/java/com/google/sps/servlets/PrefServlet.java
@@ -27,6 +27,7 @@ import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import com.google.sps.DatabaseHandler;
 
 @WebServlet("/Pref")
 public class PrefServlet extends HttpServlet {
@@ -62,12 +63,11 @@ public class PrefServlet extends HttpServlet {
       response.sendRedirect("index.jsp");
     }
 
-    entity.setProperty("q1", q1);
-    entity.setProperty("q2", q2);
-    entity.setProperty("q3", q3);
-    entity.setProperty("q4", q4);
-    entity.setProperty("q5", q5);
-    datastore.put(entity);
+    // Ensuring that only users who have filled all of the info fields out are added to the database
+    if (q1 != null && q2 != null && q3 != null && q4 != null &&
+      q5 != null) {
+      DatabaseHandler.addUserPref(id, q1, q2, q3, q4, q5);
+    }
     response.sendRedirect("profile.jsp");
   }
 }

--- a/step/src/test/java/com/google/sps/MatchManagerTest.java
+++ b/step/src/test/java/com/google/sps/MatchManagerTest.java
@@ -17,6 +17,7 @@ package com.google.sps;
 import java.util.Queue;
 import java.util.Collection;
 import java.util.Arrays;
+import java.util.HashSet;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.Before;
@@ -56,27 +57,47 @@ public final class MatchManagerTest {
     DatabaseHandler.addUser("User", "A", "1", "1", "2000", "userA@email.com", "1");
     DatabaseHandler.addUser("User", "B", "2", "2", "2002", "userB@email.com", "2");
     DatabaseHandler.addUser("User", "C", "3", "3", "2003", "userC@email.com", "3");
+    DatabaseHandler.addUser("User", "D", "4", "4", "2004", "userD@email.com", "4");
+    DatabaseHandler.addUser("User", "E", "5", "5", "2005", "userE@email.com", "5");
+    DatabaseHandler.addUser("User", "F", "6", "6", "2006", "userF@email.com", "6");
+    DatabaseHandler.addUser("User", "G", "7", "7", "2007", "userG@email.com", "7");
+    DatabaseHandler.addUserPref("1", "Yes", "No", "Yes", "Gold", "Laurel");
+    DatabaseHandler.addUserPref("2", "Yes", "No", "Yes", "Gold", "Laurel");
+    DatabaseHandler.addUserPref("3", "Yes", "No", "Yes", "Blue", "Yanny");
+    DatabaseHandler.addUserPref("4", "Yes", "No", "No", "Blue", "Yanny");
+    DatabaseHandler.addUserPref("5", "Yes", "Yes", "No", "Blue", "Yanny");
+    DatabaseHandler.addUserPref("6", "No", "No", "Yes", "Gold", "Laurel");
+    DatabaseHandler.addUserPref("7", "No", "Yes", "Yes", "Gold", "Laurel");
   }
 
   @Test
   public void testEmptyQueue() {
     // Test for when no one is in the matching queue. The user should be added to the
     // queue and their match list should be empty.
-    MatchManager.generateMatch(USER_A);
+    DatabaseHandler.addUser("User", "A", "1", "1", "2000", "userA@email.com", "1");
+    DatabaseHandler.addUserPref("1", "Yes", "No", "Yes", "Gold", "Laurel");
 
-    Queue matchQueue = MatchManager.getMatchQueue();
+    MatchManager.generateMatch(USER_A);
+    HashSet matchQueue = MatchManager.getMatchQueue();
 
     Assert.assertTrue(matchQueue.contains(USER_A));
     Assert.assertTrue(CollectionUtils.isEmpty(USER_A.getMatches()));  
   }
 
   @Test
-  public void testSuccessfulMatch() {   
+  public void testSuccessfulMatch() {
+    User USER_A = new User("1");
+    User USER_B = new User("2");
+    DatabaseHandler.addUser("User", "A", "1", "1", "2000", "userA@email.com", "1");
+    DatabaseHandler.addUserPref("1", "Yes", "No", "Yes", "Gold", "Laurel"); 
+    DatabaseHandler.addUser("User", "B", "2", "2", "2002", "userB@email.com", "2");
+    DatabaseHandler.addUserPref("2", "Yes", "No", "Yes", "Gold", "Laurel");
+
     //Test for a successful match
     MatchManager.generateMatch(USER_A);
     MatchManager.generateMatch(USER_B);
 
-    Queue matchQueue = MatchManager.getMatchQueue();
+    HashSet matchQueue = MatchManager.getMatchQueue();
 
     Assert.assertTrue(matchQueue.isEmpty());
     Assert.assertTrue(USER_A.isMatchedWith(USER_B));
@@ -85,18 +106,30 @@ public final class MatchManagerTest {
 
   @Test
   public void testUserTryingToMatchTwice() {
+    User USER_A = new User("1");
+    DatabaseHandler.addUser("User", "A", "1", "1", "2000", "userA@email.com", "1");
+    DatabaseHandler.addUserPref("1", "Yes", "No", "Yes", "Gold", "Laurel"); 
+
     // Test for when a user tries to match twice consecutively but no one else is
     // in the match queue
     MatchManager.generateMatch(USER_A);
     MatchManager.generateMatch(USER_A);
 
-    Queue matchQueue = MatchManager.getMatchQueue();
+    HashSet matchQueue = MatchManager.getMatchQueue();
 
     Assert.assertTrue(matchQueue.contains(USER_A));   
+    Assert.assertEquals(matchQueue.size(), 1);
   }
 
   @Test
   public void testUsersAlreadyMatched() {
+    User USER_A = new User("1");
+    User USER_B = new User("2");
+    DatabaseHandler.addUser("User", "A", "1", "1", "2000", "userA@email.com", "1");
+    DatabaseHandler.addUserPref("1", "Yes", "No", "Yes", "Gold", "Laurel"); 
+    DatabaseHandler.addUser("User", "B", "2", "2", "2002", "userB@email.com", "2");
+    DatabaseHandler.addUserPref("2", "Yes", "No", "Yes", "Gold", "Laurel");
+
     // Test for when a user requests a match but the only other person in the match
     // queue is someone they are already matched with
     MatchManager.generateMatch(USER_A);
@@ -105,23 +138,109 @@ public final class MatchManagerTest {
     MatchManager.generateMatch(USER_A);
     MatchManager.generateMatch(USER_B);
 
-    Queue matchQueue = MatchManager.getMatchQueue();
+    HashSet matchQueue = MatchManager.getMatchQueue();
 
     Assert.assertEquals(matchQueue.size(), 2);
     Assert.assertEquals(USER_A.getMatches().size(), 1);
     Assert.assertEquals(USER_B.getMatches().size(), 1);
+  }
 
-    // Third user enters the queue
+  // Test if there are two users in matchQueue but they have less than required mutual interests, then they won't be matched
+  @Test
+  public void testFindCompatibleMatch_minReq() {
+    User USER_A = new User("1");
+    User USER_D = new User("4");
+    DatabaseHandler.addUser("User", "A", "1", "1", "2000", "userA@email.com", "1");
+    DatabaseHandler.addUserPref("1", "Yes", "No", "Yes", "Gold", "Laurel"); 
+    DatabaseHandler.addUser("User", "D", "4", "4", "2004", "userD@email.com", "4");
+    DatabaseHandler.addUserPref("4", "Yes", "No", "No", "Blue", "Yanny");
+
+    MatchManager.generateMatch(USER_A);
+    MatchManager.generateMatch(USER_D);
+
+    HashSet matchQueue = MatchManager.getMatchQueue();
+
+    Assert.assertEquals(matchQueue.size(), 2);
+    Assert.assertEquals(USER_A.getMatches().size(), 0);
+    Assert.assertEquals(USER_D.getMatches().size(), 0);
+    Assert.assertTrue(!USER_A.isMatchedWith(USER_D));
+    Assert.assertTrue(!USER_D.isMatchedWith(USER_A));
+  }
+
+  // Return the user with the highest number of mutual interests with the first user
+  @Test
+  public void testFindMostCompatibleMatch() {
+    User USER_A = new User("1");
+    User USER_C = new User("3");
+    User USER_F = new User("6");
+    
+    DatabaseHandler.addUser("User", "A", "1", "1", "2000", "userA@email.com", "1");
+    DatabaseHandler.addUser("User", "C", "3", "3", "2003", "userC@email.com", "3");
+    DatabaseHandler.addUser("User", "F", "6", "6", "2006", "userF@email.com", "6");
+    DatabaseHandler.addUserPref("1", "Yes", "No", "Yes", "Gold", "Laurel"); 
+    DatabaseHandler.addUserPref("3", "Yes", "No", "Yes", "Blue", "Yanny");
+    DatabaseHandler.addUserPref("6", "No", "No", "Yes", "Gold", "Laurel");
+
     MatchManager.generateMatch(USER_C);
+    MatchManager.generateMatch(USER_F);
 
-    Assert.assertEquals(matchQueue.size(), 1);
+    HashSet matchQueue = MatchManager.getMatchQueue();
+
+    //USER_C & USER_F should not be matched because they have only 40% interests in common
+    Assert.assertEquals(matchQueue.size(), 2);
+    Assert.assertEquals(USER_C.getMatches().size(), 0);
+    Assert.assertEquals(USER_F.getMatches().size(), 0);
+    Assert.assertTrue(!USER_C.isMatchedWith(USER_F));
+    Assert.assertTrue(!USER_F.isMatchedWith(USER_C));
+
+    MatchManager.generateMatch(USER_A);
+
+    // USER_A & USER_C should be matched because they have 80% interests in common
+    Assert.assertEquals(MatchManager.getMatchQueue().size(), 1);
+    Assert.assertEquals(USER_A.getMatches().size(), 1);
+    Assert.assertEquals(USER_C.getMatches().size(), 0);
+    Assert.assertTrue(!USER_A.isMatchedWith(USER_C));
+    Assert.assertTrue(!USER_C.isMatchedWith(USER_A));
+    Assert.assertTrue(USER_A.isMatchedWith(USER_F));
+    Assert.assertTrue(USER_F.isMatchedWith(USER_A));
+  }
+
+  @Test
+  public void testFIFO() {
+    User USER_A = new User("1");
+    User USER_C = new User("3");
+    User USER_G = new User("7"); 
+
+    // USER_C and USER_F each have 3 mutual interests with USER_A
+    DatabaseHandler.addUser("User", "A", "1", "1", "2000", "userA@email.com", "1");
+    DatabaseHandler.addUser("User", "C", "3", "3", "2003", "userC@email.com", "3");
+    DatabaseHandler.addUser("User", "G", "6", "6", "2006", "userG@email.com", "7");
+    DatabaseHandler.addUserPref("1", "Yes", "No", "Yes", "Gold", "Laurel"); 
+    DatabaseHandler.addUserPref("3", "Yes", "No", "Yes", "Blue", "Yanny");
+    DatabaseHandler.addUserPref("7", "No", "Yes", "Yes", "Gold", "Laurel");
+
+    MatchManager.generateMatch(USER_C);
+    MatchManager.generateMatch(USER_G);
+
+    HashSet matchQueue = MatchManager.getMatchQueue();
+
+    //USER_C & USER_G should not be matched because they have only 20% interests in common
+    Assert.assertEquals(matchQueue.size(), 2);
+    Assert.assertEquals(USER_C.getMatches().size(), 0);
+    Assert.assertEquals(USER_G.getMatches().size(), 0);
+    Assert.assertTrue(!USER_C.isMatchedWith(USER_G));
+    Assert.assertTrue(!USER_G.isMatchedWith(USER_C));
+
+    // After USER_A enters the queue, USER_A should get matched with USER_C because USER_C entered the queue before USER_G
+    MatchManager.generateMatch(USER_A);
+
+    // USER_A & USER_C should be matched because they have 80% interests in common
+    Assert.assertEquals(MatchManager.getMatchQueue().size(), 1);
+    Assert.assertEquals(USER_A.getMatches().size(), 1);
+    Assert.assertEquals(USER_G.getMatches().size(), 0);
     Assert.assertTrue(USER_A.isMatchedWith(USER_C));
     Assert.assertTrue(USER_C.isMatchedWith(USER_A));
-
-    MatchManager.generateMatch(USER_C);
-
-    Assert.assertTrue(matchQueue.isEmpty());
-    Assert.assertTrue(USER_B.isMatchedWith(USER_C));
-    Assert.assertTrue(USER_C.isMatchedWith(USER_B));  
+    Assert.assertTrue(!USER_A.isMatchedWith(USER_G));
+    Assert.assertTrue(!USER_G.isMatchedWith(USER_A));
   }
 }

--- a/step/src/test/java/com/google/sps/UserTest.java
+++ b/step/src/test/java/com/google/sps/UserTest.java
@@ -53,6 +53,8 @@ public final class UserTest {
   private void addUsersToDatabase() {
     DatabaseHandler.addUser("User", "A", "1", "1", "2000", "userA@email.com", "1");
     DatabaseHandler.addUser("User", "B", "2", "2", "2002", "userB@email.com", "2");
+    DatabaseHandler.addUserPref("1", "Yes", "No", "Yes", "Gold", "Laurel");
+    DatabaseHandler.addUserPref("2", "Yes", "No", "Yes", "Gold", "Laurel");
   }
 
   @Test
@@ -70,8 +72,18 @@ public final class UserTest {
   }
 
   @Test
+  // Testing preferences fetching
+  public void testGetPreference() {
+    Assert.assertEquals(USER_A.getPreferences(), new ArrayList<>(Arrays.asList("Yes", "No", "Yes", "Gold", "Laurel")));
+    Assert.assertEquals(USER_B.getPreferences(), new ArrayList<>(Arrays.asList("Yes", "No", "Yes", "Gold", "Laurel")));
+  }
+
+  @Test
   // Testing match fetching
   public void testMatchFunctionality() {
+    User USER_A = new User("1");
+    User USER_B = new User("2");
+    addUsersToDatabase();
     // Test for when a user does not yet have any matches
     Assert.assertEquals(USER_A.getMatches(), new ArrayList<>());
 
@@ -81,9 +93,9 @@ public final class UserTest {
 
     // Test for when two users have been matched
     MatchManager.generateMatch(USER_B);
-    Assert.assertEquals(USER_A.getMatches(), new ArrayList<>(Arrays.asList(USER_B)));
     Assert.assertTrue(USER_A.isMatchedWith(USER_B));
     Assert.assertEquals(USER_B.getMatches(), new ArrayList<>(Arrays.asList(USER_A)));
+    Assert.assertEquals(USER_A.getMatches(), new ArrayList<>(Arrays.asList(USER_B)));
     Assert.assertTrue(USER_B.isMatchedWith(USER_A));  
   }
 


### PR DESCRIPTION
This PR helps match users with the one who has the most mutual interests in the list. The minimum percentage of mutual interests required for 2 users to get matched is 60%. If it's lower than it, then the user won't be matched and will be placed in pending status. 
I also switched to use HashSet to store the users waiting for matching so it's easier to remove the users from matchQueue and avoid duplicates in the list. 

Next step: Organize and store preference questions in a file which makes it easier to get edited