### PR TITLE
Hotfix: clicking on authorize button now always refreshes GCal access token

### DIFF
--- a/step/src/main/java/com/google/sps/OAuth2Utilities.java
+++ b/step/src/main/java/com/google/sps/OAuth2Utilities.java
@@ -32,8 +32,8 @@ public class OAuth2Utilities {
   public final static String CREDENTIAL_DATASTORE_ID = "credential_datastore";
   private final static String CLIENT_SECRETS_JSON_PATH = "./WEB-INF/classes/client_secrets.json";
   public final static String AUTH_REDIRECT_URI = // TODO find a way to get rid of this constant
-    "https://8080-7dc48ed0-1a8b-4df6-ba73-e55ccd2fb9ed.us-central1.cloudshell.dev/oauth2";
-    // "https://brenda-ding-pod-step-20.ue.r.appspot.com/oauth2";
+    // "https://8080-7dc48ed0-1a8b-4df6-ba73-e55ccd2fb9ed.us-central1.cloudshell.dev/oauth2";
+    "https://brenda-ding-pod-step-20.ue.r.appspot.com/oauth2";
 
 
   public static GoogleAuthorizationCodeFlow getAuthFlow()

--- a/step/src/main/java/com/google/sps/servlets/OAuth2Servlet.java
+++ b/step/src/main/java/com/google/sps/servlets/OAuth2Servlet.java
@@ -87,11 +87,11 @@ public class OAuth2Servlet extends HttpServlet {
     if (authCode == null) {
       System.out.println("Beginning authorization code flow...");
 
-      if (authFlow.loadCredential(userId) != null) { // If the user's credentials were found,
-        System.out.println("User already has a credential.\nAuthorization code flow complete.");
-        response.sendRedirect("/profile.jsp");
-        return; // we're done.
-      }
+      // if (authFlow.loadCredential(userId) != null) { // If the user's credentials were found,
+      //   System.out.println("User already has a credential.\nAuthorization code flow complete.");
+      //   response.sendRedirect("/profile.jsp");
+      //   return; // we're done.
+      // }
 
       // Redirect the user to Google's OAuth consent screen for our application.
       GoogleAuthorizationCodeRequestUrl authCodeRequestUrl = authFlow.newAuthorizationUrl();


### PR DESCRIPTION
Temporarily removed checking if a user already has a credential in OAuth2Servlet. This serves as a temporary fix to credentials not being automatically refreshed. The user can now click the authorization button and their credential will be "refreshed" every time