### PR TITLE
Type checking for birthday inputs.

### DIFF
--- a/step/src/main/webapp/infoForm.jsp
+++ b/step/src/main/webapp/infoForm.jsp
@@ -47,9 +47,9 @@ limitations under the License.
             <p><input placeholder="Last Name" oninput="this.className = ''"  name="lastName" required></p>
         </div>
         <div class="tab"> Birthday
-            <p>Day<input placeholder="dd" oninput="this.className = ''" name="dayBirth" required></p>
-            <p>Month<input placeholder="mm" oninput="this.className = ''" name="monthBirth" required></p>
-            <p>Year<input placeholder="yyyy" oninput="this.className = ''" name="yearBirth" required></p>
+            <p>Day<input placeholder="dd" oninput="this.className = ''" name="dayBirth" type="number" min="1" max="31" required></p>
+            <p>Month<input placeholder="mm" oninput="this.className = ''" name="monthBirth" type="number" min="1" max="12" required></p>
+            <p>Year<input placeholder="yyyy" oninput="this.className = ''" name="yearBirth" type="number" min="1920" max="2007" required></p>
         </div>
         <div style="overflow:auto;">
             <div style="float:right;">


### PR DESCRIPTION
Quick HTML fix to make sure that users can only put in valid inputs for the birthday section of the sign-up form. Right now it's hard coded so that no one who is under 13 in 2020 can sign up but the next step is to look into making it dynamic so that it doesn't need to be manually updated whenever the year changes. There's also a bit of a loophole cause someone who is not yet 13 but who will turn 13 this year could technically still sign up but this is just a temporary fix for now.