### PR TITLE
Profile Picture Formatting

### DIFF
--- a/step/src/main/webapp/style_profile.css
+++ b/step/src/main/webapp/style_profile.css
@@ -67,16 +67,19 @@ nav a:hover:not(.active) {
     padding: 20px;
 }
 
+#profile-pic > img {
+    width: 200px;
+    height: 200px;
+}
+
 #match-picture {
     width: 50px;
     height: 50px;
-    object-fit: cover;
-    border-radius: 50%;
 }
 
-.match-pic > img {
+#match-picture, #profile-pic > img {
+    object-fit: cover;
     border-radius: 50%;
-    width: 100px;
 }
 
 nav {


### PR DESCRIPTION
Made it so that all profile pictures, regardless of size, fit into the same frame for consistency. Using the 'cover' tag in CSS also makes sure the picture doesn't get stretched out or distorted, it just gets fitted to the frame we specify and the cropped if necessary. Also deprecated some old CSS. 